### PR TITLE
Dynamic libc

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,7 +5,7 @@ VERSION := $(shell git describe --tags | cut -d- -f1)
 CURRENT_YEAR := $(shell date +%Y)
 
 cc := musl-gcc
-cflags := -static
+cflags := -rdynamic
 cflags += -fstack-protector-all -D_FORTIFY_SOURCE=2 -fno-strict-overflow
 cflags += -Og -ggdb -DDEBUG=1 -Wall -Wextra -pedantic
 cflags += -Isrc -Ilib/tinycc -DARCH=\"MUSL\"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,8 +5,8 @@ VERSION := $(shell git describe --tags | cut -d- -f1)
 CURRENT_YEAR := $(shell date +%Y)
 
 cc := musl-gcc
-cflags := -rdynamic
-cflags += -fstack-protector-all -D_FORTIFY_SOURCE=2 -fno-strict-overflow
+
+cflags := -fstack-protector-all -D_FORTIFY_SOURCE=2 -fno-strict-overflow
 cflags += -Og -ggdb -DDEBUG=1 -Wall -Wextra -pedantic
 cflags += -Isrc -Ilib/tinycc -DARCH=\"MUSL\"
 
@@ -14,8 +14,19 @@ SOURCES := src/io.o src/file.o src/cflag.o \
 	src/cjit.o src/embed-libtcc1.o src/embed-musl-libc.o
 
 ldadd := lib/tinycc/libtcc.a
+cjit-static:cflags += -static -DCJIT_STATIC
+cjit-dynamic:cflags += -rdynamic
 
-all: deps cjit
+
+all: deps cjit-dynamic
+
+static: deps cjit-static
+
+cjit-static: cjit
+	@echo Built static version
+
+cjit-dynamic: cjit
+	@echo Built dynamic version
 
 cjit: ${SOURCES}
 	$(cc) $(cflags) -o $@ $(SOURCES) ${ldadd}

--- a/src/cjit.c
+++ b/src/cjit.c
@@ -223,13 +223,6 @@ int main(int argc, char **argv) {
   // set output in memory for just in time execution
   tcc_set_output_type(TCC, TCC_OUTPUT_MEMORY);
 
-  // simple temporary exports for hello world
-  // tcc_add_symbol(TCC, "exit", &return);
-  tcc_add_symbol(TCC, "stdout", &stdout);
-  tcc_add_symbol(TCC, "stderr", &stderr);
-  tcc_add_symbol(TCC, "fprintf", &fprintf);
-  tcc_add_symbol(TCC, "printf", &printf);
-
   if(! write_to_file(tmpdir,"libtcc1.a",&libtcc1,libtcc1_len) )
     goto endgame;
   if(! write_to_file(tmpdir,"libc.so",&musl_libc,musl_libc_len) )

--- a/src/cjit.c
+++ b/src/cjit.c
@@ -228,6 +228,21 @@ int main(int argc, char **argv) {
   if(! write_to_file(tmpdir,"libc.so",&musl_libc,musl_libc_len) )
     goto endgame;
 
+#ifdef CJIT_STATIC
+  tcc_add_symbol(TCC, "stdin", &stdin);
+  tcc_add_symbol(TCC, "stdout", &stdout);
+  tcc_add_symbol(TCC, "stderr", &stderr);
+  tcc_add_symbol(TCC, "printf", printf);
+  tcc_add_symbol(TCC, "malloc", malloc);
+  tcc_add_symbol(TCC, "free", free);
+  tcc_add_symbol(TCC, "exit", exit);
+  tcc_add_symbol(TCC, "puts", puts);
+  tcc_add_symbol(TCC, "getchar", getchar);
+  tcc_add_symbol(TCC, "putchar", putchar);
+  tcc_add_symbol(TCC, "fprintf", fprintf);
+  tcc_add_symbol(TCC, "perror", perror);
+#endif
+
   if (argc == 0) {
       printf("No input file: running in interactive mode\n");
       res = cjit_cli(TCC);


### PR DESCRIPTION
Only add a few symbols when compiling with `-static`.  Dynamic cjit now allows for automatic libc symbols and external libraries (via `#pragma comment (lib, "libname")`)
