### PR TITLE
fix: simplify include path assignment

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -29,3 +29,8 @@ check: ## 🔬 Run all tests with the currently built target
 
 clean: ## 🧹 Clean the source from all built objects
 	$(MAKE) -f build/deps.mk clean
+	@rm -f cjit
+
+PREFIX?=/usr/local
+install: cjit
+	@install cjit $(PREFIX)/bin

--- a/build/linux.mk
+++ b/build/linux.mk
@@ -2,6 +2,7 @@ include build/init.mk
 
 cc := gcc
 cflags += -DLIBC_GNU -D_GNU_SOURCE
+ldadd+=lib/tinycc/libtcc.a
 
 all: deps cjit
 

--- a/build/musl.mk
+++ b/build/musl.mk
@@ -2,9 +2,9 @@ include build/init.mk
 
 cc := musl-gcc
 cflags += -static -Os
-cflags += -Isrc -Ilib/tinycc -DLIBC_MUSL
+cflags += -Isrc -Ilib/tinycc -DLIBC_MUSL -nostdlib
 
-ldadd := lib/tinycc/libtcc.a -lc
+ldadd := lib/tinycc/libtcc.a /usr/lib/x86_64-linux-musl/crt1.o /usr/lib/x86_64-linux-musl/libc.a
 
 all: deps cjit
 

--- a/src/cjit.c
+++ b/src/cjit.c
@@ -172,8 +172,6 @@ static int cjit_cli(TCCState *TCC)
 int main(int argc, char **argv) {
   TCCState *TCC;
   const char *syntax = "[options] code.c";
-  const char *include_path = 0x0;
-  const char *libs_path = 0x0;
   const char *progname = "cjit";
   static bool verbose = false;
   static bool version = false;
@@ -211,28 +209,16 @@ int main(int argc, char **argv) {
   if(! write_to_file(tmpdir,"libtcc1.a",&libtcc1,libtcc1_len) )
     goto endgame;
 
-#if defined(LIBC_MUSL)
   //// TCC DEFAULT PATHS
   tcc_add_include_path(TCC,"/usr/include/x86_64-linux-musl");
+
+#if defined(LIBC_MUSL)
   if(! write_to_file(tmpdir,"libc.so",&musl_libc,musl_libc_len) )
     goto endgame;
 #endif
 
-#if defined(LIBC_GNU)
-  tcc_add_include_path(TCC,"lib/tinycc/include");
-#endif
-  // tcc_add_include_path(TCC,"src"); // devuan
-  if(include_path) {
-    _err("Path to headers included: %s",include_path);
-    tcc_add_include_path(TCC,include_path);
-  }
-  if(libs_path) {
-    _err("Path to libraries linked: %s",libs_path);
-    tcc_add_library_path(TCC,libs_path);
-  }
   // set output in memory for just in time execution
   tcc_set_output_type(TCC, TCC_OUTPUT_MEMORY);
-
 
 #if defined(LIBC_MUSL)
   // simple temporary exports for hello world


### PR DESCRIPTION
Both musl and gnu build can use the musl system path to resolve libc symbols/includes.

This fix removes dependencies on relative paths, so now cjit can run from anywhere.

Target `make install` added