### PR TITLE
fix: embed tinycc includes using tar

### DIFF
--- a/build/deps.mk
+++ b/build/deps.mk
@@ -16,6 +16,9 @@ src/embed-musl-libc.c:
 src/embed-libtcc1.c:
 	sh build/embed-libtcc1.sh
 
+src/embed-headers.c:
+	sh build/embed-headers.sh
+
 lib/tinycc/libtcc.a:
 	cd lib/tinycc && ./configure ${tinycc_config} \
 	&& ${MAKE} libtcc.a libtcc1.a

--- a/build/embed-headers.sh
+++ b/build/embed-headers.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+includes=lib/tinycc/include
+dst=src/embed-headers.c
+
+tmptar=`mktemp`.tar
+tar cf $tmptar ${includes}
+
+command -v xxd > /dev/null || {
+  >&2 echo "Error not found: xxd binary not installed"
+  exit 1
+}
+
+echo "// ${includes}" > $dst
+xxd -i $tmptar >> $dst
+tmpvar=`echo $tmptar | sed 's/\//_/g; s/\./_/g'`
+>&2 echo "$tmpvar"
+sed -i 's/unsigned char '"$tmpvar"'/const unsigned char tinycc_headers/' $dst
+sed -i 's/unsigned int '"$tmpvar"'/const unsigned int tinycc_headers_len/' $dst

--- a/build/init.mk
+++ b/build/init.mk
@@ -20,8 +20,9 @@ endif
 cflags := ${CFLAGS} -Isrc -Ilib/tinycc
 cflags += -fstack-protector-all -D_FORTIFY_SOURCE=2 -fno-strict-overflow
 
-SOURCES := src/io.o src/file.o src/cflag.o \
-	src/cjit.o src/embed-libtcc1.o src/embed-musl-libc.o
+SOURCES := src/io.o src/file.o src/cflag.o src/cjit.o \
+	src/embed-libtcc1.o src/embed-musl-libc.o src/embed-headers.o \
+	src/microtar.o
 
 ldadd := lib/tinycc/libtcc.a
 

--- a/build/init.mk
+++ b/build/init.mk
@@ -22,7 +22,7 @@ cflags += -fstack-protector-all -D_FORTIFY_SOURCE=2 -fno-strict-overflow
 
 SOURCES := src/io.o src/file.o src/cflag.o src/cjit.o \
 	src/embed-libtcc1.o src/embed-musl-libc.o src/embed-headers.o \
-	src/microtar.o
+	src/microtar.o src/execdir.o
 
 ldadd := lib/tinycc/libtcc.a
 

--- a/src/cjit.c
+++ b/src/cjit.c
@@ -52,6 +52,9 @@ void handle_error(void *n, const char *m) {
   _err("%s",m);
 }
 
+// from execdir.c
+bool tar_x_embedded_buffer(unsigned char src[], unsigned int len);
+
 static int cjit_exec(TCCState *TCC, const char *ep, int argc, char **argv)
 {
   pid_t pid;

--- a/src/execdir.c
+++ b/src/execdir.c
@@ -1,0 +1,68 @@
+/* CJIT https://dyne.org/cjit
+ *
+ * Copyright (C) 2024 Dyne.org foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+#include <errno.h>
+
+#include <microtar.h>
+
+// from io.c
+extern void _err(const char *fmt, ...);
+
+// embedded_headers.c
+extern char *tinycc_headers;
+extern unsigned int tinycc_headers_len;
+
+static int embed_read(mtar_t *tar, void *data, unsigned size) {
+  memcpy(data, ((char*)tar->stream)+tar->pos, size);
+  return(MTAR_ESUCCESS);
+}
+
+static int embed_seek(mtar_t *tar, unsigned offset) {
+  if(offset >= tar->max) return MTAR_ESEEKFAIL;
+  tar->pos = offset;
+  return MTAR_ESUCCESS;
+}
+
+static int embed_close(mtar_t *tar) {
+  (void)tar;
+  return MTAR_ESUCCESS;
+}
+
+bool tar_x_embedded_buffer(unsigned char src[], unsigned int len) {
+  mtar_t tar;
+  mtar_header_t h;
+  tar.stream = src;
+  tar.pos = 0;
+  tar.max = len;
+  tar.read = embed_read;
+  tar.seek = embed_seek;
+  tar.close = embed_close;
+  tar.write = NULL;
+  /* Print all file names and sizes */
+  while ( (mtar_read_header(&tar, &h)) != MTAR_ENULLRECORD ) {
+    _err("microtar_x: %s (%d bytes)\n", h.name, h.size);
+    mtar_next(&tar);
+  }
+  return true;
+}

--- a/src/microtar.c
+++ b/src/microtar.c
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2017 rxi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "microtar.h"
+
+typedef struct {
+  char name[100];
+  char mode[8];
+  char owner[8];
+  char group[8];
+  char size[12];
+  char mtime[12];
+  char checksum[8];
+  char type;
+  char linkname[100];
+  char _padding[255];
+} mtar_raw_header_t;
+
+
+static unsigned round_up(unsigned n, unsigned incr) {
+  return n + (incr - n % incr) % incr;
+}
+
+
+static unsigned checksum(const mtar_raw_header_t* rh) {
+  unsigned i;
+  unsigned char *p = (unsigned char*) rh;
+  unsigned res = 256;
+  for (i = 0; i < offsetof(mtar_raw_header_t, checksum); i++) {
+    res += p[i];
+  }
+  for (i = offsetof(mtar_raw_header_t, type); i < sizeof(*rh); i++) {
+    res += p[i];
+  }
+  return res;
+}
+
+
+static int tread(mtar_t *tar, void *data, unsigned size) {
+  int err = tar->read(tar, data, size);
+  tar->pos += size;
+  return err;
+}
+
+
+static int twrite(mtar_t *tar, const void *data, unsigned size) {
+  int err = tar->write(tar, data, size);
+  tar->pos += size;
+  return err;
+}
+
+
+static int write_null_bytes(mtar_t *tar, int n) {
+  int i, err;
+  char nul = '\0';
+  for (i = 0; i < n; i++) {
+    err = twrite(tar, &nul, 1);
+    if (err) {
+      return err;
+    }
+  }
+  return MTAR_ESUCCESS;
+}
+
+
+static int raw_to_header(mtar_header_t *h, const mtar_raw_header_t *rh) {
+  unsigned chksum1, chksum2;
+
+  /* If the checksum starts with a null byte we assume the record is NULL */
+  if (*rh->checksum == '\0') {
+    return MTAR_ENULLRECORD;
+  }
+
+  /* Build and compare checksum */
+  chksum1 = checksum(rh);
+  sscanf(rh->checksum, "%o", &chksum2);
+  if (chksum1 != chksum2) {
+    return MTAR_EBADCHKSUM;
+  }
+
+  /* Load raw header into header */
+  sscanf(rh->mode, "%o", &h->mode);
+  sscanf(rh->owner, "%o", &h->owner);
+  sscanf(rh->size, "%o", &h->size);
+  sscanf(rh->mtime, "%o", &h->mtime);
+  h->type = rh->type;
+  strcpy(h->name, rh->name);
+  strcpy(h->linkname, rh->linkname);
+
+  return MTAR_ESUCCESS;
+}
+
+
+static int header_to_raw(mtar_raw_header_t *rh, const mtar_header_t *h) {
+  unsigned chksum;
+
+  /* Load header into raw header */
+  memset(rh, 0, sizeof(*rh));
+  sprintf(rh->mode, "%o", h->mode);
+  sprintf(rh->owner, "%o", h->owner);
+  sprintf(rh->size, "%o", h->size);
+  sprintf(rh->mtime, "%o", h->mtime);
+  rh->type = h->type ? h->type : MTAR_TREG;
+  strcpy(rh->name, h->name);
+  strcpy(rh->linkname, h->linkname);
+
+  /* Calculate and write checksum */
+  chksum = checksum(rh);
+  sprintf(rh->checksum, "%06o", chksum);
+  rh->checksum[7] = ' ';
+
+  return MTAR_ESUCCESS;
+}
+
+
+const char* mtar_strerror(int err) {
+  switch (err) {
+    case MTAR_ESUCCESS     : return "success";
+    case MTAR_EFAILURE     : return "failure";
+    case MTAR_EOPENFAIL    : return "could not open";
+    case MTAR_EREADFAIL    : return "could not read";
+    case MTAR_EWRITEFAIL   : return "could not write";
+    case MTAR_ESEEKFAIL    : return "could not seek";
+    case MTAR_EBADCHKSUM   : return "bad checksum";
+    case MTAR_ENULLRECORD  : return "null record";
+    case MTAR_ENOTFOUND    : return "file not found";
+  }
+  return "unknown error";
+}
+
+
+static int file_write(mtar_t *tar, const void *data, unsigned size) {
+  unsigned res = fwrite(data, 1, size, tar->stream);
+  return (res == size) ? MTAR_ESUCCESS : MTAR_EWRITEFAIL;
+}
+
+static int file_read(mtar_t *tar, void *data, unsigned size) {
+  unsigned res = fread(data, 1, size, tar->stream);
+  return (res == size) ? MTAR_ESUCCESS : MTAR_EREADFAIL;
+}
+
+static int file_seek(mtar_t *tar, unsigned offset) {
+  int res = fseek(tar->stream, offset, SEEK_SET);
+  return (res == 0) ? MTAR_ESUCCESS : MTAR_ESEEKFAIL;
+}
+
+static int file_close(mtar_t *tar) {
+  fclose(tar->stream);
+  return MTAR_ESUCCESS;
+}
+
+
+int mtar_open(mtar_t *tar, const char *filename, const char *mode) {
+  int err;
+  mtar_header_t h;
+
+  /* Init tar struct and functions */
+  memset(tar, 0, sizeof(*tar));
+  tar->write = file_write;
+  tar->read = file_read;
+  tar->seek = file_seek;
+  tar->close = file_close;
+
+  /* Assure mode is always binary */
+  if ( strchr(mode, 'r') ) mode = "rb";
+  if ( strchr(mode, 'w') ) mode = "wb";
+  if ( strchr(mode, 'a') ) mode = "ab";
+  /* Open file */
+  tar->stream = fopen(filename, mode);
+  if (!tar->stream) {
+    return MTAR_EOPENFAIL;
+  }
+  /* Read first header to check it is valid if mode is `r` */
+  if (*mode == 'r') {
+    err = mtar_read_header(tar, &h);
+    if (err != MTAR_ESUCCESS) {
+      mtar_close(tar);
+      return err;
+    }
+  }
+
+  /* Return ok */
+  return MTAR_ESUCCESS;
+}
+
+
+int mtar_close(mtar_t *tar) {
+  return tar->close(tar);
+}
+
+
+int mtar_seek(mtar_t *tar, unsigned pos) {
+  int err = tar->seek(tar, pos);
+  tar->pos = pos;
+  return err;
+}
+
+
+int mtar_rewind(mtar_t *tar) {
+  tar->remaining_data = 0;
+  tar->last_header = 0;
+  return mtar_seek(tar, 0);
+}
+
+
+int mtar_next(mtar_t *tar) {
+  int err, n;
+  mtar_header_t h;
+  /* Load header */
+  err = mtar_read_header(tar, &h);
+  if (err) {
+    return err;
+  }
+  /* Seek to next record */
+  n = round_up(h.size, 512) + sizeof(mtar_raw_header_t);
+  return mtar_seek(tar, tar->pos + n);
+}
+
+
+int mtar_find(mtar_t *tar, const char *name, mtar_header_t *h) {
+  int err;
+  mtar_header_t header;
+  /* Start at beginning */
+  err = mtar_rewind(tar);
+  if (err) {
+    return err;
+  }
+  /* Iterate all files until we hit an error or find the file */
+  while ( (err = mtar_read_header(tar, &header)) == MTAR_ESUCCESS ) {
+    if ( !strcmp(header.name, name) ) {
+      if (h) {
+        *h = header;
+      }
+      return MTAR_ESUCCESS;
+    }
+    mtar_next(tar);
+  }
+  /* Return error */
+  if (err == MTAR_ENULLRECORD) {
+    err = MTAR_ENOTFOUND;
+  }
+  return err;
+}
+
+
+int mtar_read_header(mtar_t *tar, mtar_header_t *h) {
+  int err;
+  mtar_raw_header_t rh;
+  /* Save header position */
+  tar->last_header = tar->pos;
+  /* Read raw header */
+  err = tread(tar, &rh, sizeof(rh));
+  if (err) {
+    return err;
+  }
+  /* Seek back to start of header */
+  err = mtar_seek(tar, tar->last_header);
+  if (err) {
+    return err;
+  }
+  /* Load raw header into header struct and return */
+  return raw_to_header(h, &rh);
+}
+
+
+int mtar_read_data(mtar_t *tar, void *ptr, unsigned size) {
+  int err;
+  /* If we have no remaining data then this is the first read, we get the size,
+   * set the remaining data and seek to the beginning of the data */
+  if (tar->remaining_data == 0) {
+    mtar_header_t h;
+    /* Read header */
+    err = mtar_read_header(tar, &h);
+    if (err) {
+      return err;
+    }
+    /* Seek past header and init remaining data */
+    err = mtar_seek(tar, tar->pos + sizeof(mtar_raw_header_t));
+    if (err) {
+      return err;
+    }
+    tar->remaining_data = h.size;
+  }
+  /* Read data */
+  err = tread(tar, ptr, size);
+  if (err) {
+    return err;
+  }
+  tar->remaining_data -= size;
+  /* If there is no remaining data we've finished reading and seek back to the
+   * header */
+  if (tar->remaining_data == 0) {
+    return mtar_seek(tar, tar->last_header);
+  }
+  return MTAR_ESUCCESS;
+}
+
+
+int mtar_write_header(mtar_t *tar, const mtar_header_t *h) {
+  mtar_raw_header_t rh;
+  /* Build raw header and write */
+  header_to_raw(&rh, h);
+  tar->remaining_data = h->size;
+  return twrite(tar, &rh, sizeof(rh));
+}
+
+
+int mtar_write_file_header(mtar_t *tar, const char *name, unsigned size) {
+  mtar_header_t h;
+  /* Build header */
+  memset(&h, 0, sizeof(h));
+  strcpy(h.name, name);
+  h.size = size;
+  h.type = MTAR_TREG;
+  h.mode = 0664;
+  /* Write header */
+  return mtar_write_header(tar, &h);
+}
+
+
+int mtar_write_dir_header(mtar_t *tar, const char *name) {
+  mtar_header_t h;
+  /* Build header */
+  memset(&h, 0, sizeof(h));
+  strcpy(h.name, name);
+  h.type = MTAR_TDIR;
+  h.mode = 0775;
+  /* Write header */
+  return mtar_write_header(tar, &h);
+}
+
+
+int mtar_write_data(mtar_t *tar, const void *data, unsigned size) {
+  int err;
+  /* Write data */
+  err = twrite(tar, data, size);
+  if (err) {
+    return err;
+  }
+  tar->remaining_data -= size;
+  /* Write padding if we've written all the data for this file */
+  if (tar->remaining_data == 0) {
+    return write_null_bytes(tar, round_up(tar->pos, 512) - tar->pos);
+  }
+  return MTAR_ESUCCESS;
+}
+
+
+int mtar_finalize(mtar_t *tar) {
+  /* Write two NULL records */
+  return write_null_bytes(tar, sizeof(mtar_raw_header_t) * 2);
+}

--- a/src/microtar.h
+++ b/src/microtar.h
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2017 rxi
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT license. See `microtar.c` for details.
+ */
+
+#ifndef MICROTAR_H
+#define MICROTAR_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define MTAR_VERSION "0.1.0"
+
+enum {
+  MTAR_ESUCCESS     =  0,
+  MTAR_EFAILURE     = -1,
+  MTAR_EOPENFAIL    = -2,
+  MTAR_EREADFAIL    = -3,
+  MTAR_EWRITEFAIL   = -4,
+  MTAR_ESEEKFAIL    = -5,
+  MTAR_EBADCHKSUM   = -6,
+  MTAR_ENULLRECORD  = -7,
+  MTAR_ENOTFOUND    = -8
+};
+
+enum {
+  MTAR_TREG   = '0',
+  MTAR_TLNK   = '1',
+  MTAR_TSYM   = '2',
+  MTAR_TCHR   = '3',
+  MTAR_TBLK   = '4',
+  MTAR_TDIR   = '5',
+  MTAR_TFIFO  = '6'
+};
+
+typedef struct {
+  unsigned mode;
+  unsigned owner;
+  unsigned size;
+  unsigned mtime;
+  unsigned type;
+  char name[100];
+  char linkname[100];
+} mtar_header_t;
+
+
+typedef struct mtar_t mtar_t;
+
+struct mtar_t {
+  int (*read)(mtar_t *tar, void *data, unsigned size);
+  int (*write)(mtar_t *tar, const void *data, unsigned size);
+  int (*seek)(mtar_t *tar, unsigned pos);
+  int (*close)(mtar_t *tar);
+  void *stream;
+  unsigned pos;
+  unsigned remaining_data;
+  unsigned last_header;
+};
+
+
+const char* mtar_strerror(int err);
+
+int mtar_open(mtar_t *tar, const char *filename, const char *mode);
+int mtar_close(mtar_t *tar);
+
+int mtar_seek(mtar_t *tar, unsigned pos);
+int mtar_rewind(mtar_t *tar);
+int mtar_next(mtar_t *tar);
+int mtar_find(mtar_t *tar, const char *name, mtar_header_t *h);
+int mtar_read_header(mtar_t *tar, mtar_header_t *h);
+int mtar_read_data(mtar_t *tar, void *ptr, unsigned size);
+
+int mtar_write_header(mtar_t *tar, const mtar_header_t *h);
+int mtar_write_file_header(mtar_t *tar, const char *name, unsigned size);
+int mtar_write_dir_header(mtar_t *tar, const char *name);
+int mtar_write_data(mtar_t *tar, const void *data, unsigned size);
+int mtar_finalize(mtar_t *tar);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/microtar.h
+++ b/src/microtar.h
@@ -60,6 +60,7 @@ struct mtar_t {
   int (*close)(mtar_t *tar);
   void *stream;
   unsigned pos;
+  unsigned max;
   unsigned remaining_data;
   unsigned last_header;
 };


### PR DESCRIPTION
will be extracted in the execution tmpdir on runtime

adds microtar