### PR TITLE
ci: use fetch-depth 0 to get the tag to include in the release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,8 +62,6 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: install dependencies
         run: |
           sudo apt install -yq musl-tools musl-dev
@@ -80,8 +78,6 @@ jobs:
     runs-on: "windows-latest"
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: install dependencies
         run: |
           choco install --no-progress -r -y upx
@@ -124,7 +120,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - name: Upload release docs artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -203,8 +199,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Remove tag
         uses: dev-drprasad/delete-tag-and-release@v1.0
         with:


### PR DESCRIPTION
Version was missing on downloaded releases
