### PR TITLE
Retrieve and use CFLAGS environment variable

### DIFF
--- a/src/cjit.c
+++ b/src/cjit.c
@@ -857,6 +857,7 @@ int main(int argc, char **argv) {
   // const char *progname = "cjit";
   static bool verbose = false;
   static bool version = false;
+  static char *extra_cflags = NULL;
   char tmptemplate[] = "/tmp/CJIT-exec.XXXXXX";
   char *tmpdir = NULL;
   int res = 1;
@@ -874,6 +875,12 @@ int main(int argc, char **argv) {
   if (!TCC) {
     _err("Could not initialize tcc");
     exit(1);
+  }
+  // get the extra cflags from the CFLAGS env variable
+  if(getenv("CFLAGS")) {
+    extra_cflags = getenv("CFLAGS");
+    _err("CFLAGS: %s",extra_cflags);
+    tcc_set_options(TCC, extra_cflags);
   }
 
   // initialize the tmpdir for execution

--- a/src/cjit.c
+++ b/src/cjit.c
@@ -857,7 +857,6 @@ int main(int argc, char **argv) {
   // const char *progname = "cjit";
   static bool verbose = false;
   static bool version = false;
-  static char *extra_cflags = NULL;
   char tmptemplate[] = "/tmp/CJIT-exec.XXXXXX";
   char *tmpdir = NULL;
   int res = 1;
@@ -878,6 +877,7 @@ int main(int argc, char **argv) {
   }
   // get the extra cflags from the CFLAGS env variable
   if(getenv("CFLAGS")) {
+    char *extra_cflags = NULL;
     extra_cflags = getenv("CFLAGS");
     _err("CFLAGS: %s",extra_cflags);
     tcc_set_options(TCC, extra_cflags);

--- a/test/cflags.c
+++ b/test/cflags.c
@@ -1,0 +1,19 @@
+/* Test CFLAGS env parsing
+ * run me successfully only with:
+ *    CFLAGS="-DALLOWED=1" cjit test/cflags.c
+ */
+
+#if !defined(ALLOWED) || (ALLOWED != 1)
+
+#error Running this program is not allowed. Please compile with -DALLOWED=1
+
+#else
+
+#include <stdio.h>
+
+int main(void) 
+{
+    printf("Success.\n");
+    return 0;
+}
+#endif


### PR DESCRIPTION
tested via:

- `cjit test/cflags.c`
    -  `<string>:8: error: #error Running this program is not allowed. Please compile with -DALLOWED=1`
- `CFLAGS="ALLOWED=1" cjit test/cflags.c`
    - `Success.`
   