### PR TITLE
Feat/ketopt

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -40,7 +40,7 @@ apple-osx: ## 🍎 Build cjit.command for Apple/OSX using clang static
 _: ##
 ------: ## __ Debugging targets
 
-linux-asan: ## 🔬 Build using the address sanitizer to detect memory leaks
+debug-asan: ## 🔬 Build using the address sanitizer to detect memory leaks
 	$(MAKE) -f build/linux.mk ASAN=1
 
 _: ##

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ There are various build targets, just type `make` to have a list:
  apple-osx        🍎 Build cjit.command for Apple/OSX using clang static
  _
  ------           __ Debugging targets
- linux-asan       🔬 Build using the address sanitizer to detect memory leaks
+ debug-asan       🔬 Build using the address sanitizer to detect memory leaks
  _
  ------           __ Testing targets
  check            🧪 Run all tests using the currently built binary ./cjit

--- a/build/init.mk
+++ b/build/init.mk
@@ -14,6 +14,7 @@ endif
 CFLAGS ?= -Og -ggdb -DDEBUG=1 -Wall -Wextra
 
 cflags_includes := -Isrc -Ilib/tinycc
+cflags_gnu := -DLIBC_GNU -D_GNU_SOURCE
 cflags_stack_protect := -fstack-protector-all -D_FORTIFY_SOURCE=2 -fno-strict-overflow
 
 ifdef RELEASE

--- a/build/linux.mk
+++ b/build/linux.mk
@@ -8,6 +8,7 @@ SOURCES += src/kilo.o
 
 ifdef ASAN
 	cflags := -Og -ggdb -DDEBUG=1 -fno-omit-frame-pointer -fsanitize=address
+	cflags += ${cflags_includes} ${cflags_gnu} -DREPL_SUPPORTED
 	ldflags := -fsanitize=address -static-libasan
 #	tinycc_config += --extra-ldflags="${ldflags}"
 endif

--- a/examples/frei0r_generator.c
+++ b/examples/frei0r_generator.c
@@ -1,0 +1,95 @@
+#!/usr/bin/env cjit
+
+// this example shows how to use dynamic plugins without dlopen
+// it uses libSDL2 and frei0r video plugins (apt-get install frei0r-plugins-dev)
+
+// example usage: ./cjit frei0r_generator.c /usr/lib/frei0r-1/ising0r.so
+
+#pragma comment(lib, "SDL2")
+#define SDL_DISABLE_IMMINTRIN_H 1
+
+#include <SDL2/SDL.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <frei0r.h>
+
+#define WINDOW_WIDTH 800
+#define WINDOW_HEIGHT 600
+
+// Frei0r functions
+extern void f0r_get_plugin_info(f0r_plugin_info_t* nois0rInfo);
+extern f0r_instance_t f0r_construct(unsigned int width, unsigned int height);
+extern void f0r_destruct(f0r_instance_t instance);
+void f0r_update(f0r_instance_t instance, double time, const uint32_t* inframe, uint32_t* outframe);
+extern void f0r_destruct(f0r_instance_t instance);
+
+int main(int argc, char* argv[]) {
+    if (!f0r_get_plugin_info || !f0r_construct || !f0r_update || !f0r_destruct) {
+        fprintf(stderr, "Missing Frei0r plugin\n");
+        exit(1);
+    }
+
+    // Initialize SDL
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+        fprintf(stderr, "Failed to initialize SDL: %s\n", SDL_GetError());
+        return 1;
+    }
+
+    // Create SDL window and renderer
+    SDL_Window* window = SDL_CreateWindow("Frei0r CJIT example",
+                                          SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+                                          WINDOW_WIDTH, WINDOW_HEIGHT, SDL_WINDOW_SHOWN);
+    SDL_Renderer* renderer = SDL_CreateRenderer(window, -1, 0x0);
+    SDL_Texture* texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888,
+                                             SDL_TEXTUREACCESS_STREAMING,
+                                             WINDOW_WIDTH, WINDOW_HEIGHT);
+
+    // Create the Frei0r effect instance
+    f0r_instance_t effect_instance = f0r_construct(WINDOW_WIDTH, WINDOW_HEIGHT);
+
+    // Main loop
+    int running = 1;
+    SDL_Event event;
+    void* pixels;
+    int pitch;
+    double time= 0;
+
+    // Set the initial background color
+    SDL_LockTexture(texture, NULL, &pixels, &pitch);
+    uint32_t* pixel_ptr = (uint32_t*)pixels;
+    for (int y = 0; y < WINDOW_HEIGHT; ++y) {
+        for (int x = 0; x < WINDOW_WIDTH; ++x) {
+            pixel_ptr[y * (pitch / 4) + x] = SDL_MapRGB(SDL_AllocFormat(SDL_PIXELFORMAT_RGB888), 50, 100, 150);
+        }
+    }
+    SDL_UnlockTexture(texture);
+    while (running) {
+        while (SDL_PollEvent(&event)) {
+            if (event.type == SDL_QUIT) {
+                running = 0;
+            }
+        }
+        time += 0.1;
+
+        // Apply the Frei0r noise effect on the texture
+        SDL_LockTexture(texture, NULL, &pixels, &pitch);
+        f0r_update(effect_instance, time, NULL, pixels);  // Apply noise effect on pixels
+        SDL_UnlockTexture(texture);
+
+        // Render the updated texture
+        SDL_RenderClear(renderer);
+        SDL_RenderCopy(renderer, texture, NULL, NULL);
+        SDL_RenderPresent(renderer);
+
+    }
+
+    // Clean up
+    f0r_destruct(effect_instance);
+    SDL_DestroyTexture(texture);
+    SDL_DestroyRenderer(renderer);
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+
+    return 0;
+}

--- a/src/cjit.c
+++ b/src/cjit.c
@@ -94,6 +94,20 @@ int parse_value(char *str) {
   else return(0);
 }
 
+const char cli_help[] =
+  "\n"
+  "Synopsis: cjit [options] files(*)\n"
+  "  (*) can be any source (.c) or built object (dll, dylib, .so)\n"
+  "Options:\n"
+  " -h \t print this help\n"
+  " -v \t print version information\n"
+  " -D sym\t define a macro symbol or key=value\n"
+  " -C \t set compiler flags (default from env var CFLAGS)\n"
+  " -I dir\t also search folder 'dir' for header files\n"
+  " -l lib\t search the library named 'lib' when linking\n"
+  " -L dir\t also search inside folder 'dir' for -l libs\n"
+  " --live\t run interactive editor for live coding\n";
+
 int main(int argc, char **argv) {
   TCCState *TCC = NULL;
   // const char *progname = "cjit";
@@ -116,16 +130,28 @@ int main(int argc, char **argv) {
     tcc_set_options(TCC, extra_cflags);
   }
   static ko_longopt_t longopts[] = {
+    { "help", ko_no_argument, 100 },
     { "live", ko_no_argument, 301 },
     { NULL, 0, 0 }
   };
   ketopt_t opt = KETOPT_INIT;
   int i, c;
-  while ((c = ketopt(&opt, argc, argv, 1, "vD:L:l:C:I:", longopts)) >= 0) {
+  while ((c = ketopt(&opt, argc, argv, 1, "hvD:L:l:C:I:", longopts)) >= 0) {
     if (c == 'v') {
-      _err("Running version: %s\n",VERSION);
+      // _err("Running version: %s\n",VERSION);
+      // version is always shown
+#ifdef LIBC_MINGW32
+      _err("Built with MINGW32 libc");
+#endif
+#ifdef LIBC_MUSL
+      _err("Built with Musl libc");
+#endif
       tcc_delete(TCC);
-      exit(0); // print version and exit
+      exit(0); // print and exit
+    } else if (c=='h' || c==100) { // help
+      _err(cli_help,VERSION);
+      tcc_delete(TCC);
+      exit(0); // print and exit
     } else if (c == 'D') { // define
       int _res;
       _res = parse_value(opt.arg);

--- a/src/cjit.c
+++ b/src/cjit.c
@@ -34,6 +34,8 @@
 #include <libtcc.h>
 #include <unistd.h>
 
+#include <ketopt.h>
+
 // from file.c
 extern long  file_size(const char *filename);
 extern char* file_load(const char *filename);
@@ -69,38 +71,53 @@ void handle_error(void *n, const char *m) {
 }
 
 int main(int argc, char **argv) {
-  TCCState *TCC;
-  const char *syntax = "[options] code.c";
+  TCCState *TCC = NULL;
   // const char *progname = "cjit";
-  static bool verbose = false;
-  static bool version = false;
   char tmptemplate[] = "/tmp/CJIT-exec.XXXXXX";
   char *tmpdir = NULL;
-  char *code = NULL;
   int res = 1;
 
-  static const struct cflag options[] = {
-    CFLAG(bool, "verbose", 'v', &verbose, "Verbosely show progress"),
-    CFLAG(bool, "version", 'V', &version, "Show build version"),
-    CFLAG_HELP,
-    CFLAG_END
-  };
-  cflag_apply(options, syntax, &argc, &argv);
-  const char *code_path = argv[0];
   _err("CJIT %s by Dyne.org",VERSION);
-  if(version) exit(0); // print version and exit
 
   TCC = tcc_new();
   if (!TCC) {
     _err("Could not initialize tcc");
     exit(1);
   }
+
   // get the extra cflags from the CFLAGS env variable
+  // they are overridden by explicit command-line options
   if(getenv("CFLAGS")) {
     char *extra_cflags = NULL;
     extra_cflags = getenv("CFLAGS");
     _err("CFLAGS: %s",extra_cflags);
     tcc_set_options(TCC, extra_cflags);
+  }
+
+  ketopt_t opt = KETOPT_INIT;
+  int i, c;
+  while ((c = ketopt(&opt, argc, argv, 1, "vD:L:l:C:I:", NULL)) >= 0) {
+    if (c == 'v') {
+      _err("Running version: %s\n",VERSION);
+      tcc_delete(TCC);
+      exit(0); // print version and exit
+    } else if (c == 'D') { // define
+      _err("define: %s",opt.arg);
+      tcc_define_symbol(TCC, opt.arg, NULL); // TODO: sym=var
+    } else if (c == 'L') { // library path
+      _err("lib path: %s",opt.arg);
+      tcc_add_library_path(TCC,tmpdir);
+    } else if (c == 'l') { // library link
+      _err("lib: %s",opt.arg);
+      tcc_add_library(TCC, opt.arg);
+    } else if (c == 'C') { // library link
+      _err("cflags: %s",opt.arg);
+      tcc_set_options(TCC, opt.arg);
+    } else if (c == 'I') { // library link
+      tcc_add_include_path(TCC,opt.arg);
+    }
+    else if (c == '?') _err("unknown opt: -%c\n", opt.opt? opt.opt : ':');
+    else if (c == ':') _err("missing arg: -%c\n", opt.opt? opt.opt : ':');
   }
 
   // initialize the tmpdir for execution
@@ -126,55 +143,57 @@ int main(int argc, char **argv) {
   tcc_add_libc_symbols(TCC);
 #endif
 
-  if (argc == 0) {
-      printf("No input file: running in interactive mode\n");
-#ifdef REPL_SUPPORTED
-      res = cjit_cli_kilo(TCC);
-#else
-      res = cjit_cli_tty(TCC);
-#endif
-      goto endgame;
-  }
-  _err("Source: %s",code_path);
+//   if (argc == 0) {
+//       printf("No input file: running in interactive mode\n");
+// #ifdef REPL_SUPPORTED
+//       res = cjit_cli_kilo(TCC);
+// #else
+//       res = cjit_cli_tty(TCC);
+// #endif
+//       goto endgame;
+//   }
+//   _err("Source: %s",code_path);
 
 
-#ifndef LIBC_MINGW32 // POSIX only
-  struct stat st;
-  if (stat(code_path, &st) == -1) {
-    _err("File not found: %s",code_path);
-    goto endgame;
+  _err("Source code:");
+  for (i = opt.ind; i < argc; ++i) {
+    const char *code_path = argv[i];
+    // TODO: load entire directory
+// #ifndef LIBC_MINGW32 // POSIX only
+//     struct stat st;
+//     if (stat(code_path, &st) == -1) {
+//       _err("File not found: %s",code_path);
+//       goto endgame;
+//     }
+//     if (S_ISDIR(st.st_mode)) {
+//       _err("+ %s (dir)", code_path);
+//       tcc_add_include_path(TCC, code_path);
+//       code = dir_load(code_path);
+//   } else {
+//     code = file_load(code_path);
+//   }
+// #else
+//   /* TODO: Add Windows support for directory */
+//   code = file_load(code_path);
+// #endif
+    _err("+ %s",code_path);
+    // TODO: check if file exists
+    tcc_add_file(TCC, code_path);
   }
-  if (S_ISDIR(st.st_mode)) {
-    _err("%s: it is a directory path. Recursively adding all sources.", code_path);
-    tcc_add_include_path(TCC, code_path);
-    code = dir_load(code_path);
-  } else {
-    code = file_load(code_path);
-  }
-#else
-  /* TODO: Add Windows support for directory */
-  code = file_load(code_path);
-#endif
 
-  char *err_msg = NULL;
-  if(!code) {
-    _err("File not found: %s",code_path);
-    goto endgame;
-  }
-
-#ifdef REPL_SUPPORTED
-  _err("Start execution\n---------------");
-  res = cjit_compile_and_run(TCC, code, argc, argv, 1, &err_msg);
-  if (err_msg) {
-        _err(err_msg);
-  }
-#else
+// #ifdef REPL_SUPPORTED
+//   _err("Start execution\n---------------");
+//   res = cjit_compile_and_run(TCC, code, argc, argv, 1, &err_msg);
+//   if (err_msg) {
+//         _err(err_msg);
+//   }
+// #else
   // error handler callback for TCC
   tcc_set_error_func(TCC, stderr, handle_error);
-  if (tcc_compile_string(TCC, code) == -1) return 1;
-  free(code); // safe: bytecode compiled is in TCC now
-  code = NULL;
-  _err("Compilation successful");
+  // if (tcc_compile_string(TCC, code) == -1) return 1;
+  // free(code); // safe: bytecode compiled is in TCC now
+  // code = NULL;
+  // _err("Compilation successful");
 
   // relocate the code
   if (tcc_relocate(TCC) < 0) {
@@ -187,11 +206,13 @@ int main(int argc, char **argv) {
 #else
   res = cjit_exec_win(TCC, "main", argc, argv);
 #endif
-#endif // REPL_SUPPORTED
+// #endif // REPL_SUPPORTED
+
+  // if( tcc_run(TCC,argc,argv) == -1) res=1; else res=0;
+
   endgame:
   // free TCC
-  free(code);
-  tcc_delete(TCC);
+  if(TCC) tcc_delete(TCC);
   if(tmpdir) {
     rm_recursive(tmpdir);
   }

--- a/src/cjit.c
+++ b/src/cjit.c
@@ -226,7 +226,11 @@ int main(int argc, char **argv) {
 
   char *stdin_code = NULL;
   if(opt.ind >= argc) {
-    _err("No files specified on commandline, reading code from stdin\n");
+#ifdef LIBC_MINGW32
+    _err("No files specified on commandline");
+    goto endgame;
+#endif
+    _err("No files specified on commandline, reading code from stdin");
     stdin_code = load_stdin(); // allocated returned buffer, needs free
     if(!stdin_code) {
       _err("Error reading from standard input");
@@ -244,6 +248,10 @@ int main(int argc, char **argv) {
       _err("%c %s",(*code_path=='-'?'|':'+'),
            (*code_path=='-'?"standard input":code_path));
       if(*code_path=='-') { // stdin explicit
+#ifdef LIBC_MINGW32
+        _err("Code from standard input not supported on Windows");
+        goto endgame;
+#endif
         stdin_code = load_stdin(); // allocated returned buffer, needs free
         if(!stdin_code) {
           _err("Error reading from standard input");

--- a/src/file.c
+++ b/src/file.c
@@ -81,6 +81,9 @@ char* file_load(const char *filename) {
 }
 
 char *load_stdin() {
+#ifdef LIBC_MINGW32
+  return NULL;
+#else
   char *code = NULL;
   char *line = NULL;
   size_t len = 0;
@@ -104,6 +107,7 @@ char *load_stdin() {
     line = NULL;
   }
   return(code);
+#endif
 }
 
 bool write_to_file(char *path, char *filename, char *buf, unsigned int len) {

--- a/src/file.c
+++ b/src/file.c
@@ -80,6 +80,32 @@ char* file_load(const char *filename) {
     return contents;
 }
 
+char *load_stdin() {
+  char *code = NULL;
+  char *line = NULL;
+  size_t len = 0;
+  ssize_t rd;
+  fflush(stdout);
+  fflush(stderr);
+  while(1) {
+    rd = getline(&line, &len, stdin);
+    if(rd == -1) { // ctrl+d
+      free(line);
+      break;
+    }
+    code = realloc(code, (code?strlen(code):0) + len + 1);
+    if (!code) {
+      _err("Memory allocation error");
+      free(line);
+      return NULL;
+    }
+    strcat(code, line);
+    free(line);
+    line = NULL;
+  }
+  return(code);
+}
+
 bool write_to_file(char *path, char *filename, char *buf, unsigned int len) {
   FILE *fd;
   size_t written;

--- a/src/ketopt.h
+++ b/src/ketopt.h
@@ -1,0 +1,120 @@
+#ifndef KETOPT_H
+#define KETOPT_H
+
+#include <string.h> /* for strchr() and strncmp() */
+
+#define ko_no_argument       0
+#define ko_required_argument 1
+#define ko_optional_argument 2
+
+typedef struct {
+	int ind;   /* equivalent to optind */
+	int opt;   /* equivalent to optopt */
+	char *arg; /* equivalent to optarg */
+	int longidx; /* index of a long option; or -1 if short */
+	/* private variables not intended for external uses */
+	int i, pos, n_args;
+} ketopt_t;
+
+typedef struct {
+	char *name;
+	int has_arg;
+	int val;
+} ko_longopt_t;
+
+static ketopt_t KETOPT_INIT = { 1, 0, 0, -1, 1, 0, 0 };
+
+static void ketopt_permute(char *argv[], int j, int n) /* move argv[j] over n elements to the left */
+{
+	int k;
+	char *p = argv[j];
+	for (k = 0; k < n; ++k)
+		argv[j - k] = argv[j - k - 1];
+	argv[j - k] = p;
+}
+
+/**
+ * Parse command-line options and arguments
+ *
+ * This fuction has a similar interface to GNU's getopt_long(). Each call
+ * parses one option and returns the option name.  s->arg points to the option
+ * argument if present. The function returns -1 when all command-line arguments
+ * are parsed. In this case, s->ind is the index of the first non-option
+ * argument.
+ *
+ * @param s         status; shall be initialized to KETOPT_INIT on the first call
+ * @param argc      length of argv[]
+ * @param argv      list of command-line arguments; argv[0] is ignored
+ * @param permute   non-zero to move options ahead of non-option arguments
+ * @param ostr      option string
+ * @param longopts  long options
+ *
+ * @return ASCII for a short option; ko_longopt_t::val for a long option; -1 if
+ *         argv[] is fully processed; '?' for an unknown option or an ambiguous
+ *         long option; ':' if an option argument is missing
+ */
+static int ketopt(ketopt_t *s, int argc, char *argv[], int permute, const char *ostr, const ko_longopt_t *longopts)
+{
+	int opt = -1, i0, j;
+	if (permute) {
+		while (s->i < argc && (argv[s->i][0] != '-' || argv[s->i][1] == '\0'))
+			++s->i, ++s->n_args;
+	}
+	s->arg = 0, s->longidx = -1, i0 = s->i;
+	if (s->i >= argc || argv[s->i][0] != '-' || argv[s->i][1] == '\0') {
+		s->ind = s->i - s->n_args;
+		return -1;
+	}
+	if (argv[s->i][0] == '-' && argv[s->i][1] == '-') { /* "--" or a long option */
+		if (argv[s->i][2] == '\0') { /* a bare "--" */
+			ketopt_permute(argv, s->i, s->n_args);
+			++s->i, s->ind = s->i - s->n_args;
+			return -1;
+		}
+		s->opt = 0, opt = '?', s->pos = -1;
+		if (longopts) { /* parse long options */
+			int k, n_exact = 0, n_partial = 0;
+			const ko_longopt_t *o = 0, *o_exact = 0, *o_partial = 0;
+			for (j = 2; argv[s->i][j] != '\0' && argv[s->i][j] != '='; ++j) {} /* find the end of the option name */
+			for (k = 0; longopts[k].name != 0; ++k)
+				if (strncmp(&argv[s->i][2], longopts[k].name, j - 2) == 0) {
+					if (longopts[k].name[j - 2] == 0) ++n_exact, o_exact = &longopts[k];
+					else ++n_partial, o_partial = &longopts[k];
+				}
+			if (n_exact > 1 || (n_exact == 0 && n_partial > 1)) return '?';
+			o = n_exact == 1? o_exact : n_partial == 1? o_partial : 0;
+			if (o) {
+				s->opt = opt = o->val, s->longidx = o - longopts;
+				if (argv[s->i][j] == '=') s->arg = &argv[s->i][j + 1];
+				if (o->has_arg == 1 && argv[s->i][j] == '\0') {
+					if (s->i < argc - 1) s->arg = argv[++s->i];
+					else opt = ':'; /* missing option argument */
+				}
+			}
+		}
+	} else { /* a short option */
+		const char *p;
+		if (s->pos == 0) s->pos = 1;
+		opt = s->opt = argv[s->i][s->pos++];
+		p = strchr((char*)ostr, opt);
+		if (p == 0) {
+			opt = '?'; /* unknown option */
+		} else if (p[1] == ':') {
+			if (argv[s->i][s->pos] == 0) {
+				if (s->i < argc - 1) s->arg = argv[++s->i];
+				else opt = ':'; /* missing option argument */
+			} else s->arg = &argv[s->i][s->pos];
+			s->pos = -1;
+		}
+	}
+	if (s->pos < 0 || argv[s->i][s->pos] == 0) {
+		++s->i, s->pos = 0;
+		if (s->n_args > 0) /* permute */
+			for (j = i0; j < s->i; ++j)
+				ketopt_permute(argv, j, s->n_args);
+	}
+	s->ind = s->i - s->n_args;
+	return opt;
+}
+
+#endif

--- a/src/repl.c
+++ b/src/repl.c
@@ -46,7 +46,7 @@ int cjit_exec_win(TCCState *TCC, const char *ep, int argc, char **argv) {
   int (*_ep)(int, char**);
   _ep = tcc_get_symbol(TCC, ep);
   if (!_ep) {
-    _err("Symbol not found in source: %s","main");
+    _err("Symbol not found in source: %s",ep);
     return -1;
   }
   _err("Execution start\n---");
@@ -61,7 +61,7 @@ int cjit_exec_fork(TCCState *TCC, const char *ep, int argc, char **argv) {
   int (*_ep)(int, char**);
   _ep = tcc_get_symbol(TCC, ep);
   if (!_ep) {
-    _err("Symbol not found in source: %s","main");
+    _err("Symbol not found in source: %s",ep);
     return -1;
   }
   _err("Start execution\n---------------");


### PR DESCRIPTION
change option arguments to accept more commandline switches also multiple times
```c
  ketopt_t opt = KETOPT_INIT;
  int i, c;
  while ((c = ketopt(&opt, argc, argv, 1, "vD:L:l:C:I:", NULL)) >= 0) {
    if (c == 'v') {
      _err("Running version: %s\n",VERSION);
      tcc_delete(TCC);
      exit(0); // print version and exit
    } else if (c == 'D') { // define
      _err("define: %s",opt.arg);
      tcc_define_symbol(TCC, opt.arg, NULL); // TODO: sym=var
    } else if (c == 'L') { // library path
      _err("lib path: %s",opt.arg);
      tcc_add_library_path(TCC,tmpdir);
    } else if (c == 'l') { // library link
      _err("lib: %s",opt.arg);
      tcc_add_library(TCC, opt.arg);
    } else if (c == 'C') { // library link
      _err("cflags: %s",opt.arg);
      tcc_set_options(TCC, opt.arg);
    } else if (c == 'I') { // library link
      tcc_add_include_path(TCC,opt.arg);
    }
    else if (c == '?') _err("unknown opt: -%c\n", opt.opt? opt.opt : ':');
    else if (c == ':') _err("missing arg: -%c\n", opt.opt? opt.opt : ':');
  }
```

ketopt allows to have calls at every parsed option so they can append