### PR TITLE
fix: windows compatibility layer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,15 +80,12 @@ jobs:
     runs-on: "windows-latest"
     steps:
       - uses: actions/checkout@v4
-      # - name: install dependencies
-      #   run: |
-      #     choco install --no-progress -r -y upx
       - name: Build native windows exe for x86_64
         run: |
           make win-native
       - name: Run tests
         run: |
-          .\cjit.exe test\hello.c
+          make check CJIT=./cjit.exe
 
   osx-native-test:
     name: 🍎 OSX native test
@@ -96,9 +93,6 @@ jobs:
     runs-on: "macos-latest"
     steps:
       - uses: actions/checkout@v4
-      # - name: install dependencies
-      #   run: |
-      #     choco install --no-progress -r -y upx
       - name: Build native Apple/OSX command executable
         run: |
           make apple-osx

--- a/.github/workflows/onrelease.yml
+++ b/.github/workflows/onrelease.yml
@@ -1,0 +1,19 @@
+name: released
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  virustotal:
+    runs-on: ubuntu-latest
+    steps:
+      - name: VirusTotal Scan
+        uses: crazy-max/ghaction-virustotal@v4
+        with:
+          vt_api_key: ${{ secrets.VIRUSTOTAL_API_KEY }}
+          update_release_body: true
+          files: |
+            .exe$
+            .dll$
+            *Darwin*

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -46,14 +46,14 @@ debug-asan: ## 🔬 Build using the address sanitizer to detect memory leaks
 _: ##
 ------: ## __ Testing targets
 
+check: CJIT ?= ./cjit
 check: ## 🧪 Run all tests using the currently built binary ./cjit
-	$(if $(wildcard ./cjit),,$(error CJIT is not yet built))
-	./cjit test/hello.c
-	./cjit test/cflags.c -DALLOWED
-	./cjit test/cflags.c -DALLOWED=1
-	CFLAGS="-DALLOWED" ./cjit test/cflags.c
-	./cjit test/multifile/*
-	./cjit test/cargs.c -- a b c
+	$(if $(wildcard ${CJIT}),,$(error CJIT is not yet built: ${CJIT}))
+	${CJIT} test/hello.c
+	${CJIT} test/cflags.c -DALLOWED
+	${CJIT} test/cflags.c -DALLOWED=1
+	${CJIT} test/multifile/*
+	${CJIT} test/cargs.c -- a b c
 
 _: ##
 clean: ## 🧹 Clean the source from all built objects

--- a/build/embed-headers.sh
+++ b/build/embed-headers.sh
@@ -57,15 +57,16 @@ if [ "$1" = "win" ]; then
     echo "#endif" >> $externs
     echo "#endif" >> $calls
   }
-fi
-
-# sed inplace is not portable
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i'' -e 's/unsigned char/const char/' $dst
-  sed -i'' -e 's/unsigned int/const unsigned int/' $dst
 else
-  sed -i -e 's/unsigned char/const char/' $dst
-  sed -i -e 's/unsigned int/const unsigned int/' $dst
+  # must add const in linux or darwin
+  # sed inplace is not portable
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i'' -e 's/unsigned char/const char/' $dst
+    sed -i'' -e 's/unsigned int/const unsigned int/' $dst
+  else
+    sed -i -e 's/unsigned char/const char/' $dst
+    sed -i -e 's/unsigned int/const unsigned int/' $dst
+  fi
 fi
 
 ([ "$1" = "code" ] || [ "$2" = "code" ]) && {

--- a/build/win-native.mk
+++ b/build/win-native.mk
@@ -19,6 +19,7 @@ cflags := -O2 -fomit-frame-pointer -Isrc -Ilib/tinycc
 cflags += -DLIBC_MINGW32
 ldflags := -static-libgcc
 ldadd := lib/tinycc/libtcc.a -lshlwapi
+SOURCES += src/win-compat.o
 
 cjit.exe: ${SOURCES}
 	$(cc) $(cflags) -o $@ $(SOURCES) ${ldflags} ${ldadd}

--- a/build/win-wsl.mk
+++ b/build/win-wsl.mk
@@ -16,6 +16,8 @@ ldflags += -static-libgcc
 tinycc_config += --targetos=WIN32 --config-backtrace=no --enable-cross
 tinycc_config += --ar=${ar}
 
+SOURCES += src/win-compat.o
+
 all: deps cjit.exe
 
 cjit.exe: ${SOURCES}

--- a/src/cjit.c
+++ b/src/cjit.c
@@ -46,6 +46,8 @@ extern char* dir_load(const char *path);
 
 #ifdef LIBC_MINGW32
 extern char *win32_mkdtemp();
+// from win-compat.c
+extern void win_compat_usleep(unsigned int microseconds);
 #else
 extern char *posix_mkdtemp();
 #endif
@@ -314,6 +316,12 @@ int main(int argc, char **argv) {
   }
   // error handler callback for TCC
   tcc_set_error_func(TCC, stderr, handle_error);
+
+#ifdef LIBC_MINGW32
+  // add symbols for windows compatibility
+  tcc_add_symbol(TCC, "usleep", &win_compat_usleep);
+#endif
+
   // relocate the code (link symbols)
   if (tcc_relocate(TCC) < 0) {
     _err("TCC symbol relocation error (some library missing?)");

--- a/src/win-compat.c
+++ b/src/win-compat.c
@@ -1,0 +1,8 @@
+#include <windows.h>
+
+// Define the usleep function for Windows
+void win_compat_usleep(unsigned int microseconds) {
+    // Convert microseconds to milliseconds
+    unsigned int milliseconds = microseconds / 1000;
+    Sleep(milliseconds);
+}

--- a/src/win-compat.c
+++ b/src/win-compat.c
@@ -3,6 +3,6 @@
 // Define the usleep function for Windows
 void win_compat_usleep(unsigned int microseconds) {
     // Convert microseconds to milliseconds
-    unsigned int milliseconds = microseconds / 1000;
+    unsigned int milliseconds = microseconds >> 10; // /1024;
     Sleep(milliseconds);
 }


### PR DESCRIPTION
adding usleep symbol for C source portability

also establish a new source file to implement various compatibility wrappers needed in future for windows