### PR TITLE
Added `-n`, `-q`, and `-s` options for customizable output control

### DIFF
--- a/lib/tinycc/libtcc.c
+++ b/lib/tinycc/libtcc.c
@@ -659,6 +659,8 @@ PUB_FUNC void _tcc_error(const char *fmt, ...)
 
 PUB_FUNC void _tcc_warning(const char *fmt, ...)
 {
+    if (tcc_state->no_warnings) return;
+
     va_list ap;
     va_start(ap, fmt);
     error1(ERROR_WARN, fmt, ap);
@@ -2214,6 +2216,14 @@ PUB_FUNC void tcc_print_stats(TCCState *s1, unsigned total_time)
 #endif
     fprintf(stderr, " %d max (bytes)\n", mem_max_size);
 #endif
+}
+
+LIBTCCAPI int tcc_get_no_warnings(TCCState *s, int value) {
+    return s->no_warnings;
+}
+
+LIBTCCAPI void tcc_set_no_warnings(TCCState *s, int value) {
+    s->no_warnings = value;
 }
 
 #if ONE_SOURCE

--- a/lib/tinycc/libtcc.h
+++ b/lib/tinycc/libtcc.h
@@ -109,6 +109,10 @@ LIBTCCAPI void *_tcc_setjmp(TCCState *s1, void *jmp_buf, void *top_func, void *l
 typedef int TCCBtFunc(void *udata, void *pc, const char *file, int line, const char* func, const char *msg);
 LIBTCCAPI void tcc_set_backtrace_func(TCCState *s1, void* userdata, TCCBtFunc*);
 
+/* Allow user to disable warnings 1, enable warnings 0*/
+LIBTCCAPI void tcc_set_no_warnings(TCCState *s, int value);
+LIBTCCAPI int tcc_get_no_warnings(TCCState *s, int value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/tinycc/tcc.h
+++ b/lib/tinycc/tcc.h
@@ -756,6 +756,7 @@ struct sym_attr {
 
 struct TCCState {
     unsigned char verbose; /* if true, display some information during compilation */
+    unsigned char no_warnings; /* if true, do not display warning messages */
     unsigned char nostdinc; /* if true, no standard headers are added */
     unsigned char nostdlib; /* if true, no standard libraries are added */
     unsigned char nocommon; /* if true, do not use common symbols for .bss data */

--- a/src/io.c
+++ b/src/io.c
@@ -22,14 +22,63 @@
 #include <stdarg.h>
 #include <unistd.h>
 #include <errno.h>
+#include <stdbool.h>
 
 #define MAX_STRING 20480 // max 20KiB strings
 
+static bool no_info = false;
+static bool no_output = false;
+static bool no_errors = false;
+
+bool get_no_info() {
+  return no_info;
+}
+
+void set_no_info_output(bool val) {
+  no_info = val;
+}
+
+bool get_no_output() {
+  return no_output;
+}
+
+void set_no_output(bool val) {
+  no_output = val;
+}
+
+bool get_no_error_output() {
+  return no_errors;
+}
+
+void set_no_error_output(bool val) {
+  no_errors = val;
+}
+
 // stdout message free from context
-void _out(const char *fmt, ...) {
-  char msg[MAX_STRING+4];
+void _info(const char *fmt, ...) {
+  if (no_info) return;
+
   va_list args;
   va_start(args, fmt);
+  char msg[MAX_STRING+4];
+  int len = vsnprintf(msg, MAX_STRING, fmt, args);
+  va_end(args);
+  msg[len] = '\n';
+  msg[len+1] = 0x0; //safety
+#if defined(__EMSCRIPTEN__)
+  EM_ASM_({Module.print(UTF8ToString($0))}, msg);
+#else
+  write(STDOUT_FILENO, msg, len+1);
+#endif
+}
+
+// stdout message free from context
+void _out(const char *fmt, ...) {
+  if (no_output) return;
+
+  va_list args;
+  va_start(args, fmt);
+  char msg[MAX_STRING+4];
   int len = vsnprintf(msg, MAX_STRING, fmt, args);
   va_end(args);
   msg[len] = '\n';
@@ -43,6 +92,8 @@ void _out(const char *fmt, ...) {
 
 // error message free from context
 void _err(const char *fmt, ...) {
+  if (no_errors) return;
+
   char msg[MAX_STRING+4];
   int len;
   va_list args;

--- a/src/repl.c
+++ b/src/repl.c
@@ -32,6 +32,7 @@
 #endif
 
 // from io.c
+extern void _info(const char *fmt, ...);
 extern void _out(const char *fmt, ...);
 extern void _err(const char *fmt, ...);
 
@@ -59,7 +60,7 @@ int cjit_exec_fork(TCCState *TCC, const char *ep, int argc, char **argv) {
     _err("Symbol not found in source: %s",ep);
     return -1;
   }
-  _err("Start execution\n---------------");
+  _info("Start execution\n---------------");
   pid = fork();
   if (pid == 0) {
       res = _ep(argc, argv);


### PR DESCRIPTION
cjit.c:
- `-n` : no-info, to suppress banners and housekeeping messages.
- `-q` : quiet mode, to disable info, routine output, and libtcc warnings.
- `-s` : silent mode, to suppress all output, including errors, for silent execution. This one is pretty draconian as fatal errors are silenced.
- Switched banner and housekeeping messages to _info() from _err().

repl.c:
- Switched banner and housekeeping messages to _info() from _err().

io.c:
- Added _info() esstially a copy of _out()
- For _info(), added {set,get}_no_info_output().
- For _out(), added {set,get}_no_output().
- For _err(), added {set,get}_no_error_output()