### PR TITLE
Fix missing makefile dependencies

### DIFF
--- a/build/deps.mk
+++ b/build/deps.mk
@@ -11,7 +11,7 @@ src/embed-musl-libc.c:
 	sed -i 's/unsigned char _lib_x86_64_linux_musl_libc_so/const unsigned char musl_libc/' src/embed-musl-libc.c
 	sed -i 's/unsigned int _lib_x86_64_linux_musl_libc_so_len/const unsigned int musl_libc_len/' src/embed-musl-libc.c
 
-src/embed-libtcc1.c:
+src/embed-libtcc1.c: lib/tinycc/libtcc1.a
 	$(info Embedding libtcc1: lib/tinycc/libtcc1.a)
 	bash build/embed-libtcc1.sh lib/tinycc/libtcc1.a
 	@sed -i 's/unsigned char lib_tinycc_libtcc1_a/const unsigned char libtcc1/' src/embed-libtcc1.c
@@ -23,7 +23,7 @@ src/embed-headers.c:
 	sed -i 's/unsigned char/const char/' src/embed-headers.c
 	sed -i 's/unsigned int/const unsigned int/' src/embed-headers.c
 
-lib/tinycc/libtcc.a:
+lib/tinycc/libtcc.a lib/tinycc/libtcc1.a:
 	cd lib/tinycc && ./configure ${tinycc_config}
 	${MAKE} -C lib/tinycc libtcc.a
 	${MAKE} -C lib/tinycc libtcc1.a


### PR DESCRIPTION
Parallel builds would fail because `build/deps.mk` would attempt to use
`lib/tinycc/libtcc1.a` before it was built. This commit declares a
dependency between `src/embed-libtcc1.c` and `lib/tinycc/libtcc1.a`. With
this change in place, `make linux-x86 -j` completes without errors.

Closes #63
