### PR TITLE
Automatically detect selinux

### DIFF
--- a/build/linux.mk
+++ b/build/linux.mk
@@ -15,6 +15,10 @@ endif
 
 tinycc_config += --with-libgcc
 
+ifeq ($(shell sestatus | awk -F': *' '/SELinux status:/ {print $2}'), enabled)
+tinycc_config += --with-selinux
+endif
+
 all: lib/tinycc/libtcc.a cjit
 
 cjit: ${SOURCES}


### PR DESCRIPTION
Check if selinux is active and if so add --with-selinux to tinycc configure
command line.

Part of #62
