### PR TITLE
Fix/fileno

### DIFF
--- a/src/cjit.c
+++ b/src/cjit.c
@@ -123,7 +123,9 @@ int main(int argc, char **argv) {
   const char *default_main = "main";
   char *entry = (char*)default_main;
   bool live_mode = false;
-  bool quiet = false;
+  // quiet is by default on when cjit's output is redirected
+  // errors will still be printed on stderr
+  bool quiet = isatty(fileno(stdout))?false:true;
   int arg_separator = 0;
   int res = 1;
   int i, c;

--- a/src/io.c
+++ b/src/io.c
@@ -37,7 +37,7 @@ void _out(const char *fmt, ...) {
 #if defined(__EMSCRIPTEN__)
   EM_ASM_({Module.print(UTF8ToString($0))}, msg);
 #else
-  write(STDOUT_FILENO, msg, len+1);
+  write(fileno(stdout), msg, len+1);
 #endif
 }
 
@@ -56,6 +56,6 @@ void _err(const char *fmt, ...) {
 #elif defined(__ANDROID__)
   __android_log_print(ANDROID_LOG_ERROR, "ZEN", "%s", msg);
 #else
-  write(STDERR_FILENO,msg,len+1);
+  write(fileno(stderr),msg,len+1);
 #endif
 }

--- a/src/kilo.c
+++ b/src/kilo.c
@@ -228,7 +228,7 @@ void disableRawMode(int fd) {
 void editorAtExit(void) {
     if (!E.exiting)
         return;
-    disableRawMode(STDIN_FILENO);
+    disableRawMode(fileno(stdin));
     if ((!E.keep_scratchpad) && (E.filename)) {
         char *cp1, *dir_nm;
         cp1 = strdup(E.filename);
@@ -245,7 +245,7 @@ int enableRawMode(int fd) {
     struct termios raw;
 
     if (E.rawmode) return 0; /* Already enabled. */
-    if (!isatty(STDIN_FILENO)) goto fatal;
+    if (!isatty(fileno(stdin))) goto fatal;
     if (tcgetattr(fd,&orig_termios) == -1) goto fatal;
 
     raw = orig_termios;  /* modify the original mode */
@@ -277,9 +277,9 @@ fatal:
 int enableGetCharMode(int fd) {
     struct termios nocanon;
 
-    if (!isatty(STDIN_FILENO))
+    if (!isatty(fileno(stdin)))
         goto fatal;
-    disableRawMode(STDIN_FILENO);
+    disableRawMode(fileno(stdin));
     if (tcgetattr(fd,&orig_termios) == -1)
         goto fatal;
 
@@ -1115,7 +1115,7 @@ void editorRefreshScreen(void) {
     snprintf(buf,sizeof(buf),"\x1b[%d;%dH",E.cy+1,cx);
     abAppend(&ab,buf,strlen(buf));
     abAppend(&ab,"\x1b[?25h",6); /* Show cursor. */
-    write(STDOUT_FILENO,ab.b,ab.len);
+    write(fileno(stdout),ab.b,ab.len);
     abFree(&ab);
     /* Check for errors on new line */
     if (E.check_cb) {
@@ -1385,11 +1385,11 @@ void editorProcessKeypress(int fd) {
         E.dirty++;
         editorSave();
         strcat(ed_cmd, E.filename);
-        disableRawMode(STDIN_FILENO);
+        disableRawMode(fileno(stdin));
         editorReset();
         printf("Running %s\n", ed_cmd);
         system(ed_cmd);
-        enableRawMode(STDIN_FILENO);
+        enableRawMode(fileno(stdin));
         editorOpen();
         break;
     case CTRL_R:        /* Ctrl-r */
@@ -1445,7 +1445,7 @@ int editorFileWasModified(void) {
 }
 
 void updateWindowSize(void) {
-    if (getWindowSize(STDIN_FILENO,STDOUT_FILENO,
+    if (getWindowSize(fileno(stdin),fileno(stdout),
                       &E.screenrows,&E.screencols) == -1) {
         perror("Unable to query the screen for size (columns / rows)");
         exit(1);

--- a/src/repl.c
+++ b/src/repl.c
@@ -210,22 +210,22 @@ static int cjit_compile_buffer(void *tcs, char *code, int argc, char **argv)
     TCCState *TCC = (TCCState *)tcs;
     int res = 0;
     char *err_msg;
-    disableRawMode(STDIN_FILENO);
+    disableRawMode(fileno(stdin));
     /* Clear the screen */
-    write(STDOUT_FILENO, "\x1b[2J", 4);
+    write(fileno(stdout), "\x1b[2J", 4);
     // run the code from main
     res = cjit_compile_and_run(TCC, code, argc, argv, 1, &err_msg);
     if (err_msg) {
         _err(err_msg);
         free(err_msg);
     }
-    enableGetCharMode(STDIN_FILENO);
+    enableGetCharMode(fileno(stdin));
     _err("\n\n\n\nPress any key to continue....\n");
     getchar();
-    disableGetCharMode(STDIN_FILENO);
+    disableGetCharMode(fileno(stdin));
     free(code);
 
-    enableRawMode(STDIN_FILENO);
+    enableRawMode(fileno(stdin));
     editorRefreshScreen();
     return res;
 }
@@ -238,7 +238,7 @@ int cjit_check_buffer(void *tcs, char *code, char **err_msg) {
         *err_msg = NULL;
     // run the code from main
     //
-    disableRawMode(STDIN_FILENO);
+    disableRawMode(fileno(stdin));
     res = cjit_compile_and_run(TCC, code, 0, NULL, 0, err_msg);
     if (res != 0) {
         if(*err_msg) {
@@ -255,7 +255,7 @@ int cjit_check_buffer(void *tcs, char *code, char **err_msg) {
     } else {
         editorSetStatusMessage("No errors.");
     }
-    enableRawMode(STDIN_FILENO);
+    enableRawMode(fileno(stdin));
     return res;
 }
 
@@ -305,7 +305,7 @@ int cjit_cli_kilo(TCCState *TCC) {
             editorInsertRow(row++, editor_rows[i], strlen(editor_rows[i]));
         }
 
-        enableRawMode(STDIN_FILENO);
+        enableRawMode(fileno(stdin));
         editorSetStatusMessage(
                 "HELP: Cx-S = save | Cx-Q = quit | Cx-F = find | Cx-R = run | Cx-E = editor");
         while(1) {
@@ -313,7 +313,7 @@ int cjit_cli_kilo(TCCState *TCC) {
             editorSetCheckCallback(cjit_check_buffer);
             editorSetCompilerContext(TCC);
             editorRefreshScreen();
-            editorProcessKeypress(STDIN_FILENO);
+            editorProcessKeypress(fileno(stdin));
         }
     }
     return res;


### PR DESCRIPTION
##    fix: make quiet mode default when redirecting output

    this eases developer experience, supposing people redirecting cjit's
    output are using it into a script and anyway know already how it works
    fix #65
-----
##    fix: use fileno(3) instead of STDOUT_FILENO defines

    this improves POSIX compliancy and facilitates the juggling of file
    descriptors from callers